### PR TITLE
Allow sprint syntax in fallback config

### DIFF
--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -110,6 +110,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   # Then, if logstash received an event with the field `foo` set to `bar`, the destination
   # field would be set to `bar`. However, if logstash received an event with `foo` set to `nope`,
   # then the destination field would still be populated, but with the value of `no match`.
+  # This configuration can be dynamic and include parts of the event using the `%{field}` syntax.
   config :fallback, :validate => :string
 
   public
@@ -185,7 +186,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
       end
 
       if not matched and @fallback
-        event[@destination] = @fallback
+        event[@destination] = event.sprintf(@fallback)
         matched = true
       end
       filter_matched(event) if matched or @field == @destination

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -67,4 +67,36 @@ describe LogStash::Filters::Translate do
     end
   end
 
+  describe "fallback value - static configuration" do
+    config <<-CONFIG
+      filter {
+        translate {
+          field       => "status"
+          destination => "translation"
+          fallback => "no match"
+        }
+      }
+    CONFIG
+
+    sample("status" => "200") do
+      insist { subject["translation"] } == "no match"
+    end
+  end
+
+  describe "fallback value - allow sprintf" do
+    config <<-CONFIG
+      filter {
+        translate {
+          field       => "status"
+          destination => "translation"
+          fallback => "%{missing_translation}"
+        }
+      }
+    CONFIG
+
+    sample("status" => "200", "missing_translation" => "no match") do
+      insist { subject["translation"] } == "no match"
+    end
+  end
+
 end


### PR DESCRIPTION
Fix for https://github.com/elasticsearch/logstash-contrib/issues/151