### PR TITLE
implemented dictionary_url

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2015 Elasticsearch <http://www.elasticsearch.org>
+Copyright (c) 2012–2015 Elasticsearch <http://www.elastic.co>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -1,0 +1,5 @@
+Elasticsearch
+Copyright 2012-2015 Elasticsearch
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Need Help?
 
-Need help? Try #logstash on freenode IRC or the logstash-users@googlegroups.com mailing list.
+Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Developing
 

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -121,6 +121,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   # Then, if logstash received an event with the field `foo` set to `bar`, the destination
   # field would be set to `bar`. However, if logstash received an event with `foo` set to `nope`,
   # then the destination field would still be populated, but with the value of `no match`.
+  # This configuration can be dynamic and include parts of the event using the `%{field}` syntax.
   config :fallback, :validate => :string
 
   public
@@ -223,7 +224,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
       end
 
       if not matched and @fallback
-        event[@destination] = @fallback
+        event[@destination] = event.sprintf(@fallback)
         matched = true
       end
       filter_matched(event) if matched or @field == @destination

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -1,15 +1,18 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "open-uri"
 
 # A general search and replace tool which uses a configured hash
-# and/or a YAML file to determine replacement values.
+# and/or a YAML file or a Web service with a YAML response to determine replacement values.
 #
-# The dictionary entries can be specified in one of two ways: First,
+# The dictionary entries can be specified in one of three ways: First,
 # the `dictionary` configuration item may contain a hash representing
 # the mapping. Second, an external YAML file (readable by logstash) may be specified
 # in the `dictionary_path` configuration item. These two methods may not be used
 # in conjunction; it will produce an error.
+# Third, a Web service who your request produces a YML response. This may not be 
+# used in conjunction with the first and second method; it will produce an error.
 #
 # Operationally, if the event field specified in the `field` configuration
 # matches the EXACT contents of a dictionary entry key (or matches a regex if
@@ -50,7 +53,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   #                         "old version", "new version" ]
   #       }
   #     }
-  # NOTE: it is an error to specify both `dictionary` and `dictionary_path`
+  # NOTE: it is an error to specify both `dictionary` and `dictionary_path` or `dictionary_url`
   config :dictionary, :validate => :hash,  :default => {}
 
   # The full path of the external YAML dictionary file. The format of the table
@@ -62,11 +65,18 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   #     merci: gracias
   #     old version: new version
   #     
-  # NOTE: it is an error to specify both `dictionary` and `dictionary_path`
+  # NOTE: it is an error to specify both `dictionary` and `dictionary_path` or `dictionary_url`
   config :dictionary_path, :validate => :path
 
-  # When using a dictionary file, this setting will indicate how frequently
-  # (in seconds) logstash will check the YAML file for updates.
+  # The full URI path of a Web service who generates an yml format response. 
+  # The response generated needs to be equals than needed for @dictionary_path
+  config :dictionary_url, :validate => :string
+
+  # Filename (without extension) where .yml will be stored from a Web service.
+  config :file_to_download, :validate => :string, :default => "dictionary"
+
+  # When using a dictionary file or url, this setting will indicate how frequently
+  # (in seconds) logstash will check the YAML file or url for updates.
   config :refresh_interval, :validate => :number, :default => 300
   
   # The destination field you wish to populate with the translated code. The default
@@ -118,6 +128,13 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
       registering = true
       load_yaml(registering)
     end
+    if @dictionary_url
+      @next_refresh = Time.now + @refresh_interval
+      registering = true
+      @logger.warn(@dictionary_url)
+      @logger.warn(@file_to_download)
+      download_yaml(@dictionary_url,@file_to_download)
+    end
     
     @logger.debug? and @logger.debug("#{self.class.name}: Dictionary - ", :dictionary => @dictionary)
     if @exact
@@ -127,23 +144,38 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
     end
   end # def register
 
-  public
-  def load_yaml(registering=false)
-    if !File.exists?(@dictionary_path)
-      @logger.warn("dictionary file read failure, continuing with old dictionary", :path => @dictionary_path)
+  private
+  def load_file(registering,fileName)
+    if !File.exists?(fileName)
+      @logger.warn("dictionary file read failure, continuing with old dictionary", :path => fileName)
       return
     end
 
     begin
-      @dictionary.merge!(YAML.load_file(@dictionary_path))
+      @dictionary.merge!(YAML.load_file(fileName))
     rescue Exception => e
       if registering
-        raise "#{self.class.name}: Bad Syntax in dictionary file #{@dictionary_path}"
+        raise "#{self.class.name}: Bad Syntax in dictionary file #{fileName}"
       else
-        @logger.warn("#{self.class.name}: Bad Syntax in dictionary file, continuing with old dictionary", :dictionary_path => @dictionary_path)
+        @logger.warn("#{self.class.name}: Bad Syntax in dictionary file, continuing with old dictionary", :dictionary_path => fileName)
       end
     end
-  end
+  end # def load_file
+
+  public
+  def load_yaml(registering=false)
+    load_file(registering,@dictionary_path)
+  end # def load_yaml
+
+  public
+  def download_yaml(path,filename)
+    File.open(filename+".yml", "wb") do |saved_file|
+      open(path, "rb") do |read_file|
+        saved_file.write(read_file.read)
+      end
+    end
+    load_file(true,filename+".yml")
+  end # def download_yaml
 
   public
   def filter(event)
@@ -154,6 +186,14 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
         load_yaml
         @next_refresh = Time.now + @refresh_interval
         @logger.info("refreshing dictionary file")
+      end
+    end
+
+    if @dictionary_url
+      if @next_refresh < Time.now
+        download_yaml(@dictionary_url,@file_to_download)
+        @next_refresh = Time.now + @refresh_interval
+        @logger.info("downloading and refreshing dictionary file")
       end
     end
     

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -70,6 +70,8 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
 
   # The full URI path of a Web service who generates an yml format response. 
   # The response generated needs to be equals than needed for @dictionary_path
+  #
+  # NOTE: it is an error to specify both `dictionary` and `dictionary_path` or `dictionary_url`
   config :dictionary_url, :validate => :string
 
   # Filename (without extension) where .yml will be stored from a Web service.
@@ -130,9 +132,6 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
     end
     if @dictionary_url
       @next_refresh = Time.now + @refresh_interval
-      registering = true
-      @logger.warn(@dictionary_url)
-      @logger.warn(@file_to_download)
       download_yaml(@dictionary_url,@file_to_download)
     end
     

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |s|
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A general search and replace tool which uses a configured hash and/or a YAML file to determine replacement values."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors         = ["Elasticsearch"]
-  s.email           = 'info@elasticsearch.com'
-  s.homepage        = "http://www.elasticsearch.org/guide/en/logstash/current/index.html"
+  s.authors         = ["Elastic"]
+  s.email           = 'info@elastic.co'
+  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ["lib"]
 
   # Files

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '0.1.8'
+  s.version         = '0.1.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A general search and replace tool which uses a configured hash and/or a YAML file to determine replacement values."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -67,4 +67,36 @@ describe LogStash::Filters::Translate do
     end
   end
 
+  describe "fallback value - static configuration" do
+    config <<-CONFIG
+      filter {
+        translate {
+          field       => "status"
+          destination => "translation"
+          fallback => "no match"
+        }
+      }
+    CONFIG
+
+    sample("status" => "200") do
+      insist { subject["translation"] } == "no match"
+    end
+  end
+
+  describe "fallback value - allow sprintf" do
+    config <<-CONFIG
+      filter {
+        translate {
+          field       => "status"
+          destination => "translation"
+          fallback => "%{missing_translation}"
+        }
+      }
+    CONFIG
+
+    sample("status" => "200", "missing_translation" => "no match") do
+      insist { subject["translation"] } == "no match"
+    end
+  end
+
 end


### PR DESCRIPTION
New functionality. You can use a URL that needs to show a yml format,
then you don’t need to put an yml file for each logstash server and
maintain it. You only need to change the web service.