### PR TITLE
Disallow simultaneous use of 'dictionary' and 'dictionary_path'

### DIFF
--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -128,6 +128,15 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
     @read_lock = rw_lock.readLock
     @write_lock = rw_lock.writeLock
     
+    if @dictionary_path && !@dictionary.empty?
+      raise LogStash::ConfigurationError, I18n.t(
+        "logstash.agent.configuration.invalid_plugin_register",
+        :plugin => "filter",
+        :type => "translate",
+        :error => "The configuration options 'dictionary' and 'dictionary_path' are mutually exclusive"
+      )
+    end
+
     if @dictionary_path
       @next_refresh = Time.now + @refresh_interval
       raise_exception = true

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -180,4 +180,19 @@ describe LogStash::Filters::Translate do
       end
     end
   end
+
+  describe "general configuration" do
+    let(:dictionary_path)  { File.join(File.dirname(__FILE__), "..", "fixtures", "dict.yml") }
+    let(:config) do
+      {
+        "field"            => "random field",
+        "dictionary"       => { "a" => "b" },
+        "dictionary_path"  => dictionary_path,
+      }
+    end
+
+    it "raises an exception if both 'dictionary' and 'dictionary_path' are set" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
 end


### PR DESCRIPTION
While the documentation mentions in several places that the 'dictionary' and 'dictionary_path' options can't both be used, but there was nothing in the code to stop that incorrect usage. With this commit a LogStash::ConfigurationError is raised in #register.