### PR TITLE
Fix threadsafety issues with a read/write lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
+# 2.1.4
+  - Fix threadsafety issues by adding in a read/write lock
+
 # 2.1.3
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.1.2
   - New dependency requirements for logstash-core for the 5.0 release
 ## 2.1.1
   - Add more descriptive message with the dictionary could not be loaded,
-  also include test for it. 
+  also include test for it.
 
 ## 2.1.0
   - Added other formats, a part from YAML, to be used when loading
@@ -12,7 +15,7 @@
   YAML, JSON and CSV.
 
 ## 2.0.0
-  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
   instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
   - Dependency on logstash-core update to 2.0
 

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '2.1.3'
+  s.version         = '2.1.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A general search and replace tool which uses a configured hash and/or a YAML file to determine replacement values."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This plugin was not threadsafe at all. Multiple dictionary loads could occur simultaneously ballooning memory usage. Also, ruby hashes aren't guaranteed to be threadsafe!

Fixes #27