### PR TITLE
Translate ip on cidr keys to values

### DIFF
--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -193,8 +193,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
             matched = true
           end
         elsif @cidr
-          ip = NetAddr::CIDR.create(source)
-          key = @dictionary.keys.detect{ |k| NetAddr::CIDR.create(k).matches?(ip) }
+          key = @dictionary.keys.detect{ |k| NetAddr::CIDR.create(k).matches?(source) }
           if key
             event[@destination] = lock_for_read { @dictionary[key] }
             matched = true

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "netaddr", "~> 1.5"
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '~> 0'
 end
-


### PR DESCRIPTION
I have information that I can only pinpoint by an internal ip.
In my case this is different to geoip, therefore I was looking for a way to translate an ip to data based on an ip range mapping.
There is the logstash cidr filter and maybe I got it wrong, but it seems not to fully meet the requirement of translating an ip address to further data based on a cidr range.

Using regex with ip ranges does work well, but leads to a rather confusing list.
The `netaddr` gem is used to check if an ip is within a cidr. Testcases are added as well.

An example would be `mapping.yml`:

``` yaml
'10.10.10.0/24' : 'This mapping to ip specific data'
'10.10.11.0/24' : 'This mapping to further ip specific data'
```

Maybe this is of some interest.
Tests in a low-load real world scenario look promising.
