### PR TITLE
5.0.0 events and less strict dependency constraint on logstash-core-plugin-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 sudo: false
 language: ruby
 cache: bundler
+jdk:
+- oraclejdk8
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+- jruby-1.7.25
+before_script:
+- bundle exec rake vendor
+script:
+- bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.0
+  - Breaking: Updated plugin to use new Java Event APIs
+
 # 2.1.4
   - Fix threadsafety issues by adding in a read/write lock
 

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -187,30 +187,30 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
 
     begin
       #If source field is array use first value and make sure source value is string
-      source = event[@field].is_a?(Array) ? event[@field].first.to_s : event[@field].to_s
+      source = event.get(@field).is_a?(Array) ? event.get(@field).first.to_s : event.get(@field).to_s
       matched = false
       if @exact
         if @regex
           key = @dictionary.keys.detect{|k| source.match(Regexp.new(k))}
           if key
-            event[@destination] = lock_for_read { @dictionary[key] }
+            event.set(@destination, lock_for_read { @dictionary[key] })
             matched = true
           end
         elsif @dictionary.include?(source)
-          event[@destination] = lock_for_read { @dictionary[source] }
+          event.set(@destination, lock_for_read { @dictionary[source] })
           matched = true
         end
       else
         translation = lock_for_read { source.gsub(Regexp.union(@dictionary.keys), @dictionary) }
         
         if source != translation
-          event[@destination] = translation.force_encoding(Encoding::UTF_8)
+          event.set(@destination, translation.force_encoding(Encoding::UTF_8))
           matched = true
         end
       end
 
       if not matched and @fallback
-        event[@destination] = event.sprintf(@fallback)
+        event.set(@destination, event.sprintf(@fallback))
         matched = true
       end
       filter_matched(event) if matched or @field == @destination

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '2.1.4'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "A general search and replace tool which uses a configured hash and/or a YAML file to determine replacement values."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -27,7 +27,7 @@ describe LogStash::Filters::Translate do
     it "return the exact translation" do
       subject.register
       subject.filter(event)
-      expect(event["translation"]).to eq("OK")
+      expect(event.get("translation")).to eq("OK")
     end
   end
 
@@ -52,7 +52,7 @@ describe LogStash::Filters::Translate do
     it "return the exact translation" do
       subject.register
       subject.filter(event)
-      expect(event["translation"]).to eq("OK & Server Error")
+      expect(event.get("translation")).to eq("OK & Server Error")
     end
 
   end
@@ -77,7 +77,7 @@ describe LogStash::Filters::Translate do
     it "return the exact translation" do
       subject.register
       subject.filter(event)
-      expect(event["translation"]).to eq("OK")
+      expect(event.get("translation")).to eq("OK")
     end
   end
 
@@ -97,7 +97,7 @@ describe LogStash::Filters::Translate do
       it "return the exact translation" do
         subject.register
         subject.filter(event)
-        expect(event["translation"]).to eq("no match")
+        expect(event.get("translation")).to eq("no match")
       end
     end
 
@@ -115,7 +115,7 @@ describe LogStash::Filters::Translate do
       it "return the exact translation" do
         subject.register
         subject.filter(event)
-        expect(event["translation"]).to eq("missing no match")
+        expect(event.get("translation")).to eq("missing no match")
       end
     end
   end
@@ -146,7 +146,7 @@ describe LogStash::Filters::Translate do
       it "return the exact translation" do
         subject.register
         subject.filter(event)
-        expect(event["translation"]).to eq(1)
+        expect(event.get("translation")).to eq(1)
       end
     end
 
@@ -157,7 +157,7 @@ describe LogStash::Filters::Translate do
       it "return the exact translation" do
         subject.register
         subject.filter(event)
-        expect(event["translation"]).to eq(20)
+        expect(event.get("translation")).to eq(20)
       end
     end
 
@@ -168,7 +168,7 @@ describe LogStash::Filters::Translate do
       it "return the exact translation" do
         subject.register
         subject.filter(event)
-        expect(event["translation"]).to eq("300")
+        expect(event.get("translation")).to eq("300")
       end
     end
 


### PR DESCRIPTION
Updated plugin to use 5.0 events and changed dependency constrain on logstash-core-plugin-api so that the plugin can be installed on logstash v5.0.0-alpha3 and later.