### PR TITLE
Feature/redis backend support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gemspec
+gem 'redis', '~>3.2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 gem 'redis', '~>3.2'
+group :test, :development do
+  gem 'mock_redis', '~> 0.17.1'
+end

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -195,4 +195,35 @@ describe LogStash::Filters::Translate do
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
   end
+
+  describe "redis backend should not support non exact matches" do
+    let(:config) do
+      {
+        "field"            => "random field",
+        "dictionary_path"  => 'redis://localhost',
+        "exact"  => false
+      }
+    end
+
+    it "raises an exception if redis is used and 'exact' is set to false" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  describe "redis backend should not support regex based translations" do
+    let(:config) do
+      {
+        "field"            => "random field",
+        "dictionary_path"  => 'redis://localhost',
+        "exact"  => true,
+        "regex"  => true,
+      }
+    end
+
+    it "raises an exception if redis is used and 'regex' is set to true" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+
 end


### PR DESCRIPTION
I really would like to see this on the main stream. This is a first working version with lots of room for improvements, but being able to use REDIS as a dictionary backend has a lot of benefits.
In my company for example, we wrote an agent that listens to Active Directory network logon Events and record an "ip => user" entry on a REDIS database. This way we can use the translate filter to map every firewall, ssh and other logs that contain an IP address to a user at an especific point in time.
