### PR TITLE
Refresh dictionary only if it's changed on disk

### DIFF
--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -81,7 +81,12 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
 
   # When using a dictionary file, this setting will indicate how frequently
   # (in seconds) logstash will check the dictionary file for updates.
-  config :refresh_interval, :validate => :number, :default => 300
+  config :refresh_interval, :validate => :number, :default => 5
+  # when using a dictionary file, if this is set to true, the dictionary's
+  # modification time will be checked before reloaded.  If the dictionary
+  # isn't modified, the refresh won't happen.  If you set this to false,
+  # increase the refresh_interval.
+  config :refresh_only_if_modified, :validate => :boolean, :default => true
 
   # The destination field you wish to populate with the translated code. The default
   # is a field named `translation`. Set this to the same value as source if you want
@@ -179,7 +184,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
           if needs_refresh?
             load_dictionary
             @next_refresh = Time.now + @refresh_interval
-            @logger.info("refreshing dictionary file")
+            @logger.info("refreshing dictionary file #{@dictionary_path"")
           end
         end
       end
@@ -225,6 +230,9 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   private
 
   def load_dictionary(raise_exception=false)
+    if (@refresh_only_if_modified)
+      @dictionary_mtime = File.mtime(@dictionary_path)
+    end
     if /.y[a]?ml$/.match(@dictionary_path)
       load_yaml(raise_exception)
     elsif @dictionary_path.end_with?(".json")
@@ -280,6 +288,20 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
   end
 
   def needs_refresh?
-    @next_refresh < Time.now
+    now = Time.now
+    if @next_refresh > now
+      return false
+    end
+    if @refresh_only_if_modified
+      mtime = File.mtime(@dictionary_path)
+      if mtime != @dictionary_mtime
+        return true
+      else
+        @next_refresh = now + @refresh_interval
+        return false
+      end
+    else
+      return true
+    end
   end
 end # class LogStash::Filters::Translate

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -184,7 +184,7 @@ class LogStash::Filters::Translate < LogStash::Filters::Base
           if needs_refresh?
             load_dictionary
             @next_refresh = Time.now + @refresh_interval
-            @logger.info("refreshing dictionary file #{@dictionary_path"")
+            @logger.info("refreshing dictionary file #{@dictionary_path}")
           end
         end
       end


### PR DESCRIPTION
Add an option to refresh the dictionary file only if it changes.  Look at the file
modification time and if it changes, refresh the file.  The refresh interval
is used to determine how often to check the modification time, so change the
interval down to 5 seconds by default
