### PR TITLE
Improving guide for `refresh_behaviour`

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -215,8 +215,9 @@ Note: this is activated only when `exact => true`.
   * Default value is `merge`
 
 When using a dictionary file, this setting indicates how the update will be executed.
-Setting this to `merge` leads to entries removed from the dictionary file being kept;
-`replace` deletes old entries on update.
+Setting this to `merge` leads merging new dictionary on old dictionary. This means 
+same entry will be updated but entries removed from new dictianary will be kept with exist value;
+`replace` leads replacing whole dictionary with new one and deletes all old entries on update.
 
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -215,9 +215,10 @@ Note: this is activated only when `exact => true`.
   * Default value is `merge`
 
 When using a dictionary file, this setting indicates how the update will be executed.
-Setting this to `merge` leads merging new dictionary on old dictionary. This means 
-same entry will be updated but entries removed from new dictianary will be kept with exist value;
-`replace` leads replacing whole dictionary with new one and deletes all old entries on update.
+Setting this to `merge` causes the new dictionary to be merged into the old one. This means 
+same entry will be updated but entries that existed before but not in the new dictionary 
+will remain after the merge; `replace` causes the whole dictionary to be replaced 
+with a new one (deleting all entries of the old one on update).
 
 
 


### PR DESCRIPTION
Add more information for clear understanding about the options `merge` and `refresh`.

Original guide is only talking about the entries deleted from updated dictionary. After found the exact code for this and understanding what does merge functions do exactly from [here](https://apidock.com/ruby/Hash/merge), I have finally understood the concept and context.

So I suggest to improve a part of guide including more context and exact behaviour for the entries which is updated w/ new value from new dictionary. 
