### PR TITLE
Fix dictionary example

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -93,9 +93,9 @@ Example:
     filter {
       translate {
         dictionary => { 
-          "100"         => "Continue",
-          "101"         => "Switching Protocols",
-          "merci"       => "thank you",
+          "100"         => "Continue"
+          "101"         => "Switching Protocols"
+          "merci"       => "thank you"
           "old version" => "new version"
         }
       }


### PR DESCRIPTION
Removed commas in `dictionary` example

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
