### PR TITLE
[Docs] Explain why integers must be quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.3
+  - Added info to dictionary_path description to explain why integers must be quoted
+
 ## 3.2.2
   - Fix bug in csv_file when LS config has CSV filter plugin specified as well as a csv dictionary.
   [#70](https://github.com/logstash-plugins/logstash-filter-translate/issues/70)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.3
+## master
   - Added info to dictionary_path description to explain why integers must be quoted
 
 ## 3.2.2

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,11 +24,14 @@ A general search and replace tool that uses a configured hash
 and/or a file to determine replacement values. Currently supported are
 YAML, JSON, and CSV files. Each dictionary item is a key value pair.
 
-The dictionary entries can be specified in one of two ways: First,
-the `dictionary` configuration item may contain a hash representing
-the mapping. Second, an external file (readable by logstash) may be specified
-in the `dictionary_path` configuration item. These two methods may not be used
-in conjunction; it will produce an error.
+The dictionary entries can be specified in one of two ways: 
+
+* The `dictionary` configuration item can contain a hash representing
+the mapping. 
+* An external file (readable by logstash) may be specified in the
+`dictionary_path` configuration item. 
+
+These two methods may not be used in conjunction; it will produce an error.
 
 Operationally, for each event, the value from the `field` setting is tested
 against the dictionary and if it matches exactly (or matches a regex when
@@ -146,9 +149,11 @@ NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
-The full path of the external dictionary file. The format of the table
-should be a standard YAML, JSON, or CSV. Make sure you specify any integer-based keys
-in quotes. For example, the YAML file should look something like this:
+The full path of the external dictionary file. The format of the table should be
+a standard YAML, JSON, or CSV. Specify any integer-based keys in quotes. The
+parser is expecting a string, and the quotes make the integer-based keys
+function as a string. For example, the YAML file should look something like
+this:
 
 [source,ruby]
 ----

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,7 @@ A general search and replace tool that uses a configured hash
 and/or a file to determine replacement values. Currently supported are
 YAML, JSON, and CSV files. Each dictionary item is a key value pair.
 
-The dictionary entries can be specified in one of two ways: 
+You can specify dictionary entries in one of two ways: 
 
 * The `dictionary` configuration item can contain a hash representing
 the mapping. 
@@ -150,10 +150,13 @@ NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
   * There is no default value for this setting.
 
 The full path of the external dictionary file. The format of the table should be
-a standard YAML, JSON, or CSV. Specify any integer-based keys in quotes. The
-parser is expecting a string, and the quotes make the integer-based keys
-function as a string. For example, the YAML file should look something like
-this:
+a standard YAML, JSON, or CSV. 
+
+Specify any integer-based keys in quotes. The
+value taken from the event's `field` setting is converted to a string. The
+lookup dictionary keys must also be strings, and the quotes make the
+integer-based keys function as a string. For example, the YAML file should look
+something like this:
 
 [source,ruby]
 ----
@@ -359,8 +362,10 @@ A value of zero or less will disable refresh.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-If you'd like to treat dictionary keys as regular expressions, set `regex => true`.
-Note: this is activated only when `exact => true`.
+To treat dictionary keys as regular expressions, set `regex => true`.
+
+Be sure to escape dictionary key strings for use with regex.
+Resources on regex formatting are available online.
 
 [id="plugins-{type}s-{plugin}-refresh_behaviour"]
 ===== `refresh_behaviour`

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '3.2.2'
+  s.version         = '3.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field contents based on a hash or YAML file"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #73 
Minor reformatting to emphasize either/or `dictionary` or `dictionary_path` config options
