### PR TITLE
Clarify substitution use case

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -113,9 +113,8 @@ filter plugins.
   * Default value is `"translation"`
 
 The destination field you wish to populate with the translated code. The default
-is a field named `translation`. Set this to the same value as source if you want
-to do a substitution, in this case filter will allways succeed. This will clobber
-the old value of the source field!
+is a field named `translation`. If you want to do a substitution, set this to the 
+same value as `field` and set `override` to `true`.  
 
 [id="plugins-{type}s-{plugin}-dictionary"]
 ===== `dictionary`


### PR DESCRIPTION
Setting `destination` to be the same as `field` (i.e, the source field) does not work unless `override` is also set to `true`.  This clarifies the configuration required for the substitution use case.

