### PR TITLE
optionally use event.sprintf on dictionary values

### DIFF
--- a/lib/logstash/filters/array_of_maps_value_update.rb
+++ b/lib/logstash/filters/array_of_maps_value_update.rb
@@ -2,13 +2,14 @@
 
 module LogStash module Filters
   class ArrayOfMapsValueUpdate
-    def initialize(iterate_on, field, destination, fallback, lookup)
+    def initialize(iterate_on, field, destination, fallback, lookup, dynamic)
       @iterate_on = ensure_reference_format(iterate_on)
       @field = ensure_reference_format(field)
       @destination = ensure_reference_format(destination)
       @fallback = fallback
       @use_fallback = !fallback.nil? # fallback is not nil, the user set a value in the config
       @lookup = lookup
+      @dynamic = dynamic
     end
 
     def test_for_inclusion(event, override)
@@ -27,7 +28,7 @@ module LogStash module Filters
         matched = [true, nil]
         @lookup.fetch_strategy.fetch(inner.to_s, matched)
         if matched.first
-          event.set(nested_destination, matched.last)
+          event.set(nested_destination, @dynamic ? event.sprintf(matched.last) : matched.last)
           matches[index] = true
         elsif @use_fallback
           event.set(nested_destination, event.sprintf(@fallback))

--- a/lib/logstash/filters/array_of_values_update.rb
+++ b/lib/logstash/filters/array_of_values_update.rb
@@ -9,12 +9,13 @@ module LogStash module Filters
       def call(source) Array(source); end
     end
 
-    def initialize(iterate_on, destination, fallback, lookup)
+    def initialize(iterate_on, destination, fallback, lookup, dynamic)
       @iterate_on = iterate_on
       @destination = destination
       @fallback = fallback
       @use_fallback = !fallback.nil? # fallback is not nil, the user set a value in the config
       @lookup = lookup
+      @dynamic = dynamic
       @coercers_table = {}
       @coercers_table.default = CoerceOther.new
       @coercers_table[Array] = CoerceArray.new
@@ -37,7 +38,7 @@ module LogStash module Filters
         matched = [true, nil]
         @lookup.fetch_strategy.fetch(inner.to_s, matched)
         if matched.first
-          target[index] = matched.last
+          target[index] = @dynamic ? event.sprintf(matched.last) : matched.last
         end
       end
       event.set(@destination, target)

--- a/lib/logstash/filters/single_value_update.rb
+++ b/lib/logstash/filters/single_value_update.rb
@@ -12,11 +12,12 @@ module LogStash module Filters
       def call(source) source.to_s end
     end
 
-    def initialize(field, destination, fallback, lookup)
+    def initialize(field, destination, fallback, lookup, dynamic)
       @field = field
       @destination = destination
       @fallback = fallback
       @use_fallback = !fallback.nil? # fallback is not nil, the user set a value in the config
+      @dynamic = dynamic
       @lookup = lookup
       @coercers_table = {}
       @coercers_table.default = CoerceOther.new
@@ -38,7 +39,7 @@ module LogStash module Filters
       matched = [true, nil]
       @lookup.fetch_strategy.fetch(source, matched)
       if matched.first
-        event.set(@destination, matched.last)
+        event.set(@destination, @dynamic ? event.sprintf(matched.last) : matched.last)
       elsif @use_fallback
         event.set(@destination, event.sprintf(@fallback))
         matched[0] = true

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -150,6 +150,9 @@ class Translate < LogStash::Filters::Base
   # the field to write the looked up value (or the `fallback` value) to with `destination`
   config :iterate_on, :validate => :string
 
+  # If you'd like dictionary values to be evaluated dynamically set `dynamic => true`.
+  config :dynamic, :validate => :boolean, :default => false
+
   attr_reader :lookup # for testing reloading
 
   def register
@@ -168,11 +171,11 @@ class Translate < LogStash::Filters::Base
       @lookup = Dictionary::Memory.new(@dictionary, @exact, @regex)
     end
     if @iterate_on.nil?
-      @updater = SingleValueUpdate.new(@field, @destination, @fallback, @lookup)
+      @updater = SingleValueUpdate.new(@field, @destination, @fallback, @lookup, @dynamic)
     elsif @iterate_on == @field
-      @updater = ArrayOfValuesUpdate.new(@iterate_on, @destination, @fallback, @lookup)
+      @updater = ArrayOfValuesUpdate.new(@iterate_on, @destination, @fallback, @lookup, @dynamic)
     else
-      @updater = ArrayOfMapsValueUpdate.new(@iterate_on, @field, @destination, @fallback, @lookup)
+      @updater = ArrayOfMapsValueUpdate.new(@iterate_on, @field, @destination, @fallback, @lookup, @dynamic)
     end
 
     @logger.debug? && @logger.debug("#{self.class.name}: Dictionary - ", :dictionary => @lookup.dictionary)


### PR DESCRIPTION
Introduces new configuration parameter `dynamic` that will enable use of event.sprintf on replacement values. `dynamic` defaults to `false` to not impact performance for current users of the plugin.

I added tests for `single_value_update.rb`, but not for `array_of_maps_value_update.rb` and `array_of_values_update.rb` yet.

Resolves #80. CC @guyboertje, as he's assigned to that issue.