### PR TITLE
Clarify how to use translate filter to substitute

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -113,7 +113,7 @@ filter plugins.
   * Default value is `"translation"`
 
 The destination field you wish to populate with the translated code. The default
-is a field named `translation`. Set this to the same value as source if you want
+is a field named `translation`. Set this to the same value as source (with `override => true`) if you want
 to do a substitution, in this case filter will allways succeed. This will clobber
 the old value of the source field!
 


### PR DESCRIPTION
Add the clarification that you need `override => true` if you want to use the translate filter for a substitution. (I've seen several people, myself included, getting confused by this before eventually finding out about the override setting)