### PR TITLE
Feat: ECS compatible default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.3.0
   - Feat: added ECS compatibility mode [#89](https://github.com/logstash-plugins/logstash-filter-translate/pull/89)
     - deprecated `destination` option in favor of `target` to better align with other plugins
+    - deprecated `field` option in favor of `source` to better align with other plugins
     - when ECS compatibility is enabled, default behaviour is an in-place translation
   - Fix: improved error handling - do not rescue potentially fatal (JVM) errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+  - Feat: ECS compatible default behavior [#89](https://github.com/logstash-plugins/logstash-filter-translate/pull/89)
+  - Fix: improved error handling - do not rescue potentially fatal (JVM) errors
+
 ## 3.2.3
   - Fix to align with docs - looked-up values are always strings. Coerce better. [#77](https://github.com/logstash-plugins/logstash-filter-translate/pull/77)
   - Fix bug in dictionary/file the always applied RegexExact, manifested when dictionary keys are not regex compatible [Logstash #9936](https://github.com/elastic/logstash/issues/9936)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.3.0
-  - Feat: ECS compatible default behavior [#89](https://github.com/logstash-plugins/logstash-filter-translate/pull/89)
+  - Feat: added ECS compatibility mode [#89](https://github.com/logstash-plugins/logstash-filter-translate/pull/89)
+    - deprecated `destination` option in favor of `target` to better align with other plugins
+    - when ECS compatibility is enabled, default behaviour is an in-place translation
   - Fix: improved error handling - do not rescue potentially fatal (JVM) errors
 
 ## 3.2.3

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -82,7 +82,7 @@ processing half-baked dictionary content.
 
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-The plugin acts as an in place translator if `field` and `target` are the same
+The plugin acts as an in-place translator if `field` and `target` are the same
 and does not produce any new event fields.
 This is the default behavior in <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,8 +44,8 @@ Example:
 ----
     filter {
       translate {
-        field => "[http_status]"
-        destination => "[http_status_description]"
+        field => "[http][response][status_code]"
+        target => "[http_status_description]"
         dictionary => {
           "100" => "Continue"
           "101" => "Switching Protocols"
@@ -80,6 +80,12 @@ Any ongoing modification of the dictionary file should be done using a
 copy/edit/rename or create/rename mechanism to avoid the refresh code from
 processing half-baked dictionary content.
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+The plugin acts as an in place translator if `field` and `target` are the same
+and does not produce any new event fields.
+This is the default behavior in <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Translate Filter Configuration Options
 
@@ -91,6 +97,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-destination>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-dictionary>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-dictionary_path>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exact>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-fallback>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-field>> |<<string,string>>|Yes
@@ -99,6 +106,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-refresh_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-regex>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-refresh_behaviour>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -110,12 +118,13 @@ filter plugins.
 ===== `destination`
 
   * Value type is <<string,string>>
-  * Default value is `"translation"`
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"translation"`
+    ** ECS Compatibility enabled: defaults to the same value as `field`
+  * This option is deprecated
 
-The destination field you wish to populate with the translated code. The default
-is a field named `translation`. Set this to the same value as source if you want
-to do a substitution, in this case filter will allways succeed. This will clobber
-the old value of the source field!
+NOTE: This option is deprecated and it will be removed in the next major version of Logstash.
+Use <<plugins-{type}s-{plugin}-target>> instead.
 
 [id="plugins-{type}s-{plugin}-dictionary"]
 ===== `dictionary`
@@ -172,6 +181,20 @@ The currently supported formats are YAML, JSON, and CSV. Format selection is
 based on the file extension: `json` for JSON, `yaml` or `yml` for YAML, and
 `csv` for CSV. The CSV format expects exactly two columns, with the first serving
 as the original text (lookup key), and the second column as the translation.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: disabled ECS-compatibility
+    ** `v1`: compatibility with Elastic Common Schema 1.x
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target>>.
 
 [id="plugins-{type}s-{plugin}-exact"]
 ===== `exact`
@@ -379,7 +402,17 @@ same entry will be updated but entries that existed before but not in the new di
 will remain after the merge; `replace` causes the whole dictionary to be replaced
 with a new one (deleting all entries of the old one on update).
 
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
 
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"translation"`
+    ** ECS Compatibility enabled: defaults to the same value as `field`
+
+The target field you wish to populate with the translated code.
+Set this to the same value as source `field` causes the plugin to do a substitution,
+in this case filter will always succeed. This will clobber the old value of the source field!
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -80,6 +80,7 @@ Any ongoing modification of the dictionary file should be done using a
 copy/edit/rename or create/rename mechanism to avoid the refresh code from
 processing half-baked dictionary content.
 
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 The plugin acts as an in-place translator if `field` and `target` are the same

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -366,7 +366,7 @@ After
   * Value type is <<boolean,boolean>>
   * Default value depends on whether in-place translation is being used
 
-If the destination (or target) field already exists, this configuration item specifies
+If the destination (or target) field already exists, this configuration option controls
 whether the filter skips translation (default behavior) or overwrites the target
 field value with the new translation value.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -415,8 +415,8 @@ with a new one (deleting all entries of the old one on update).
     ** ECS Compatibility enabled: defaults to the same value as `field`
 
 The target field you wish to populate with the translated code.
-Set this to the same value as source `field` causes the plugin to do a substitution,
-in this case filter will always succeed. This will clobber the old value of the source field!
+If you set this value to the same value as source `field`, the plugin does a substitution, and
+the filter will succeed. This will clobber the old value of the source field!
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -159,11 +159,10 @@ NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
 The full path of the external dictionary file. The format of the table should be
 a standard YAML, JSON, or CSV. 
 
-Specify any integer-based keys in quotes. The
-value taken from the event's `field` setting is converted to a string. The
-lookup dictionary keys must also be strings, and the quotes make the
-integer-based keys function as a string. For example, the YAML file should look
-something like this:
+Specify any integer-based keys in quotes. The value taken from the event's
+`source` setting is converted to a string. The lookup dictionary keys must also
+be strings, and the quotes make the integer-based keys function as a string.
+For example, the YAML file should look something like this:
 
 [source,ruby]
 ----
@@ -258,14 +257,14 @@ When the value that you need to perform enrichment on is a variable sized array
 then specify the field name in this setting. This setting introduces two modes,
 1) when the value is an array of strings and 2) when the value is an array of
 objects (as in JSON object). +
-In the first mode, you should have the same field name in both `field` and
+In the first mode, you should have the same field name in both `source` and
 `iterate_on`, the result will be an array added to the field specified in the
-`destination` setting. This array will have the looked up value (or the
+`target` setting. This array will have the looked up value (or the
 `fallback` value or nil) in same ordinal position as each sought value. +
 In the second mode, specify the field that has the array of objects in
 `iterate_on` then specify the field in each object that provides the sought value
-with `field` and the field to write the looked up value (or the `fallback` value)
-to with `destination`.
+with `source` and the field to write the looked up value (or the `fallback` value)
+to with `target`.
 
 For a dictionary of:
 [source,csv]
@@ -281,8 +280,8 @@ Example of Mode 1
     filter {
       translate {
         iterate_on => "[collaborator_ids]"
-        field      => "[collaborator_ids]"
-        destination => "[collaborator_names]"
+        source     => "[collaborator_ids]"
+        target     => "[collaborator_names]"
         fallback => "Unknown"
       }
     }
@@ -305,9 +304,9 @@ Example of Mode 2
     filter {
       translate {
         iterate_on => "[collaborators]"
-        field      => "[id]"
-        destination => "[name]"
-        fallback => "Unknown"
+        source     => "[id]"
+        target     => "[name]"
+        fallback   => "Unknown"
       }
     }
 
@@ -363,7 +362,7 @@ If the destination (or target) field already exists, this configuration option c
 whether the filter skips translation (default behavior) or overwrites the target
 field value with the new translation value.
 
-In case of in-place translation, where `@target` is the same as `@field` (such as when
+In case of in-place translation, where `target` is the same as `source` (such as when
 <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled), overwriting is allowed.
 
 [id="plugins-{type}s-{plugin}-refresh_interval"]
@@ -417,10 +416,10 @@ If this field is an array, only the first value will be used.
   * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
     ** ECS Compatibility disabled: `"translation"`
-    ** ECS Compatibility enabled: defaults to the same value as `field`
+    ** ECS Compatibility enabled: defaults to the same value as `source`
 
 The target field you wish to populate with the translated code.
-If you set this value to the same value as source `field`, the plugin does a substitution, and
+If you set this value to the same value as `source` field, the plugin does a substitution, and
 the filter will succeed. This will clobber the old value of the source field!
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -367,7 +367,7 @@ After
   * Default value depends on whether in-place translation is being used
 
 If the destination (or target) field already exists, this configuration item specifies
-whether the filter should skip translation (default behavior) or overwrite the target
+whether the filter skips translation (default behavior) or overwrites the target
 field value with the new translation value.
 
 In case of in-place translation, where `@target` is the same as `@field` (such as when

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -119,9 +119,6 @@ filter plugins.
 ===== `destination`
 
   * Value type is <<string,string>>
-  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
-    ** ECS Compatibility disabled: `"translation"`
-    ** ECS Compatibility enabled: defaults to the same value as `field`
   * This option is deprecated
 
 NOTE: This option is deprecated and it will be removed in the next major version of Logstash.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -101,11 +101,12 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exact>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-fallback>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-field>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-iterate_on>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-override>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-refresh_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-regex>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-refresh_behaviour>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
@@ -119,10 +120,11 @@ filter plugins.
 ===== `destination`
 
   * Value type is <<string,string>>
-  * This option is deprecated
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"translation"`
+    ** ECS Compatibility enabled: field is no longer supported
 
-NOTE: This option is deprecated and it will be removed in the next major version of Logstash.
-Use <<plugins-{type}s-{plugin}-target>> instead.
+deprecated[3.3.0, Use <<plugins-{type}s-{plugin}-target>> instead. In 4.0 this setting will be removed.]
 
 [id="plugins-{type}s-{plugin}-dictionary"]
 ===== `dictionary`
@@ -243,14 +245,10 @@ This configuration can be dynamic and include parts of the event using the `%{fi
 [id="plugins-{type}s-{plugin}-field"]
 ===== `field`
 
-  * This is a required setting.
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The name of the logstash event field containing the value to be compared for a
-match by the translate filter (e.g. `message`, `host`, `response_code`).
-
-If this field is an array, only the first value will be used.
+deprecated[3.3.0, Use <<plugins-{type}s-{plugin}-source>> instead. In 4.0 this setting will be removed.]
 
 [id="plugins-{type}s-{plugin}-iterate_on"]
 ===== `iterate_on`
@@ -402,6 +400,18 @@ Setting this to `merge` causes the new dictionary to be merged into the old one.
 same entry will be updated but entries that existed before but not in the new dictionary
 will remain after the merge; `replace` causes the whole dictionary to be replaced
 with a new one (deleting all entries of the old one on update).
+
+[id="plugins-{type}s-{plugin}-source"]
+===== `source`
+
+* This is a required setting.
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+The name of the logstash event field containing the value to be compared for a
+match by the translate filter (e.g. `message`, `host`, `response_code`).
+
+If this field is an array, only the first value will be used.
 
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -83,7 +83,7 @@ processing half-baked dictionary content.
 [id="plugins-{type}s-{plugin}-ecs_metadata"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-The plugin acts as an in-place translator if `field` and `target` are the same
+The plugin acts as an in-place translator if `source` and `target` are the same
 and does not produce any new event fields.
 This is the default behavior in <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
 
@@ -120,9 +120,7 @@ filter plugins.
 ===== `destination`
 
   * Value type is <<string,string>>
-  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
-    ** ECS Compatibility disabled: `"translation"`
-    ** ECS Compatibility enabled: field is no longer supported
+  * Deprecated alias for <<plugins-{type}s-{plugin}-target>> setting.
 
 deprecated[3.3.0, Use <<plugins-{type}s-{plugin}-target>> instead. In 4.0 this setting will be removed.]
 
@@ -188,7 +186,7 @@ as the original text (lookup key), and the second column as the translation.
   * Value type is <<string,string>>
   * Supported values are:
     ** `disabled`: disabled ECS-compatibility
-    ** `v1`: compatibility with Elastic Common Schema 1.x
+    ** `v1`, `v8`: compatibility with the specified major version of the Elastic Common Schema
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
     ** Otherwise, the default value is `disabled`.
@@ -246,7 +244,7 @@ This configuration can be dynamic and include parts of the event using the `%{fi
 ===== `field`
 
   * Value type is <<string,string>>
-  * There is no default value for this setting.
+  * Deprecated alias for <<plugins-{type}s-{plugin}-source>> setting.
 
 deprecated[3.3.0, Use <<plugins-{type}s-{plugin}-source>> instead. In 4.0 this setting will be removed.]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -363,11 +363,14 @@ After
 ===== `override`
 
   * Value type is <<boolean,boolean>>
-  * Default value is `false`
+  * Default value depends on whether in-place translation is being used
 
 If the destination (or target) field already exists, this configuration item specifies
-whether the filter should skip translation (default) or overwrite the target field
-value with the new translation value.
+whether the filter should skip translation (default behavior) or overwrite the target
+field value with the new translation value.
+
+In case of in-place translation, where `@target` is the same as `@field` (such as when
+<<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled), overwriting is allowed.
 
 [id="plugins-{type}s-{plugin}-refresh_interval"]
 ===== `refresh_interval`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,18 +33,17 @@ the mapping.
 
 These two methods may not be used in conjunction; it will produce an error.
 
-Operationally, for each event, the value from the `field` setting is tested
+Operationally, for each event, the value from the `source` setting is tested
 against the dictionary and if it matches exactly (or matches a regex when
-`regex` configuration item has been enabled), the matched value is put in
-the `destination` field, but on no match the `fallback` setting string is
-used instead.
+`regex` configuration item has been enabled), the matched value is put in the
+`target` field, but on no match the `fallback` setting string is used instead.
 
 Example:
 [source,ruby]
 ----
     filter {
       translate {
-        field => "[http][response][status_code]"
+        source => "[http][response][status_code]"
         target => "[http_status_description]"
         dictionary => {
           "100" => "Continue"
@@ -131,7 +130,7 @@ deprecated[3.3.0, Use <<plugins-{type}s-{plugin}-target>> instead. In 4.0 this s
   * Default value is `{}`
 
 The dictionary to use for translation, when specified in the logstash filter
-configuration item (i.e. do not use the `@dictionary_path` file).
+configuration item (i.e. do not use the `dictionary_path` file).
 
 Example:
 [source,ruby]

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -157,6 +157,7 @@ class Translate < LogStash::Filters::Base
   config :iterate_on, :validate => :string
 
   attr_reader :lookup # for testing reloading
+  attr_reader :updater # for tests
 
   def register
     if @dictionary_path && !@dictionary.empty?
@@ -202,9 +203,9 @@ class Translate < LogStash::Filters::Base
   def filter(event)
     return unless @updater.test_for_inclusion(event, @override)
     begin
-    rescue Exception => e
       filter_matched(event) if @updater.update(event) || @field == @target
-      @logger.error("Something went wrong when attempting to translate from dictionary", :exception => e, :field => @field, :event => event)
+    rescue => e
+      @logger.error("Something went wrong when attempting to translate from dictionary", :exception => e, :field => @field, :event => event.to_hash)
     end
   end # def filter
 end # class LogStash::Filters::Translate

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -38,7 +38,7 @@ require_relative "array_of_maps_value_update"
 module LogStash module Filters
 class Translate < LogStash::Filters::Base
 
-  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
   extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
 

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require 'logstash/plugin_mixins/ecs_compatibility_support'
 
 require "logstash/filters/dictionary/memory"
 require "logstash/filters/dictionary/file"
@@ -35,6 +36,9 @@ require_relative "array_of_maps_value_update"
 # you might consider using the gsub function of the mutate filter.
 module LogStash module Filters
 class Translate < LogStash::Filters::Base
+
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1)
+
   config_name "translate"
 
   # The name of the logstash event field containing the value to be compared for a

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -178,7 +178,7 @@ class Translate < LogStash::Filters::Base
     if @target && @destination
       raise LogStash::ConfigurationError, "Please remove `destination => #{@destination.inspect}` and only set the `target => ...` option instead"
     end
-    @target ||= @destination || 'translation'
+    @target ||= @destination || ecs_select[disabled: 'translation', v1: @field]
 
     if @iterate_on.nil?
       @updater = SingleValueUpdate.new(@field, @target, @fallback, @lookup)

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -182,7 +182,10 @@ class Translate < LogStash::Filters::Base
     if @target && @destination
       raise LogStash::ConfigurationError, "Please remove `destination => #{@destination.inspect}` and only set the `target => ...` option instead"
     end
-    @target ||= @destination || ecs_select[disabled: 'translation', v1: @field]
+    if ecs_select[disabled: false, v1: @destination] # do not support using `destination => ... in ECS mode
+      raise LogStash::ConfigurationError, "Please remove `destination => #{@destination.inspect}` and set the `target => ...` option instead"
+    end
+    @target ||= ecs_select[disabled: (@destination || 'translation'), v1: @field]
 
     if @field == @target
       @override = true if @override.nil?

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.2'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~> 1.0'
   s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.2'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.1'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.2'
   s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '3.2.3'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field contents based on a hash or YAML file"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.1'
   s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/filters/scheduling_spec.rb
+++ b/spec/filters/scheduling_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'rspec/wait'
 require "logstash/devutils/rspec/spec_helper"
 require "support/rspec_wait_handler_helper"
 require "support/build_huge_dictionaries"

--- a/spec/filters/scheduling_spec.rb
+++ b/spec/filters/scheduling_spec.rb
@@ -15,8 +15,8 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-        "field"       => "[status]",
-        "destination" => "[translation]",
+        "source"      => "[status]",
+        "target"      => "[translation]",
         "dictionary_path"  => dictionary_path.to_path,
         "exact"       => true,
         "regex"       => false,
@@ -106,8 +106,8 @@ describe LogStash::Filters::Translate do
     let(:dictionary_size) { 100000 }
     let(:config) do
       {
-        "field"       => "[status]",
-        "destination" => "[translation]",
+        "source"      => "[status]",
+        "target"      => "[translation]",
         "dictionary_path"  => dictionary_path.to_path,
         "exact"       => true,
         "regex"       => false,
@@ -155,8 +155,8 @@ describe LogStash::Filters::Translate do
     let(:dictionary_size) { 100000 }
     let(:config) do
       {
-        "field"       => "[status]",
-        "destination" => "[translation]",
+        "source"      => "[status]",
+        "target"      => "[translation]",
         "dictionary_path"  => dictionary_path.to_path,
         "exact"       => true,
         "regex"       => false,

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -18,7 +18,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "field"       => "status",
-        "destination" => "translation",
+        "target"      => "translation",
         "dictionary"  => [ "200", "OK",
                            "300", "Redirect",
                            "400", "Client Error",
@@ -42,7 +42,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "field"       => "status",
-        "destination" => "translation",
+        "target"      => "translation",
         "dictionary"  => [ "^2\\d\\d", "OK",
                            "^3\\d\\d", "Redirect",
                            "^4\\d\\d", "Client Error",
@@ -66,7 +66,7 @@ describe LogStash::Filters::Translate do
       let(:config) do
         {
           "field"       => "status",
-          "destination" => "translation",
+          "target"      => "translation",
           "dictionary"  => [ "200", "OK",
                              "300", "Redirect",
                              "400", "Client Error",
@@ -90,7 +90,7 @@ describe LogStash::Filters::Translate do
       let(:config) do
         {
           "field"       => "status",
-          "destination" => "translation",
+          "target"      => "translation",
           "dictionary_path" => dictionary_path,
           "refresh_interval" => 0,
           "exact"       => false,
@@ -113,7 +113,7 @@ describe LogStash::Filters::Translate do
       let(:config) do
         {
           "field"       => "status",
-          "destination" => "translation",
+          "target"      => "translation",
           "dictionary"  => [ "^2[0-9][0-9]$", "OK",
                              "^3[0-9][0-9]$", "Redirect",
                              "^4[0-9][0-9]$", "Client Error",
@@ -137,7 +137,7 @@ describe LogStash::Filters::Translate do
       let(:config) do
         {
           "field"       => "status",
-          "destination" => "translation",
+          "target"      => "translation",
           "dictionary_path" => dictionary_path,
           "refresh_interval" => 0,
           "exact"       => true,
@@ -160,8 +160,8 @@ describe LogStash::Filters::Translate do
     context "static configuration" do
       let(:config) do
         {
-          "field"       => "status",
-          "destination" => "translation",
+          "field"    => "status",
+          "target"   => "translation",
           "fallback" => "no match"
         }
       end
@@ -178,8 +178,8 @@ describe LogStash::Filters::Translate do
     context "allow sprintf" do
       let(:config) do
         {
-          "field"       => "status",
-          "destination" => "translation",
+          "field"    => "status",
+          "target"   => "translation",
           "fallback" => "%{missing_translation}"
         }
       end
@@ -201,7 +201,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "field"       => "status",
-        "destination" => "translation",
+        "target"      => "translation",
         "dictionary_path"  => dictionary_path,
         "refresh_interval" => -1,
         "exact"       => true,
@@ -360,7 +360,7 @@ describe LogStash::Filters::Translate do
     end
   end
 
-  describe "general configuration" do
+  context "invalid dictionary configuration" do
     let(:dictionary_path)  { TranslateUtil.build_fixture_path("dict.yml") }
     let(:config) do
       {
@@ -375,6 +375,20 @@ describe LogStash::Filters::Translate do
     end
   end
 
+  context "invalid target+dictionary configuration" do
+    let(:config) do
+      {
+          "field"       => "message",
+          "target"      => 'foo',
+          "destination" => 'bar',
+      }
+    end
+
+    it "raises an exception if both 'target' and 'destination' are set" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
   describe "refresh_behaviour" do
     let(:dictionary_content) { "a : 1\nb : 2\nc : 3" }
     let(:modified_content) { "a : 1\nb : 4" }
@@ -383,7 +397,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "field" => "status",
-        "destination" => "translation",
+        "target" => "translation",
         "dictionary_path" => dictionary_path,
         "refresh_interval" => -1, # we're controlling this manually
         "exact" => true,
@@ -450,7 +464,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "field"       => "status",
-        "destination" => "translation",
+        "target"      => "translation",
         "dictionary_path"  => dictionary_path.to_path,
         "refresh_interval" => -1,
         "fallback" => "no match",

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -18,7 +18,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-        "field"       => "status",
+        "source"      => "status",
         "target"      => "translation",
         "dictionary"  => [ "200", "OK",
                            "300", "Redirect",
@@ -42,7 +42,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-        "field"       => "status",
+        "source"      => "status",
         "target"      => "translation",
         "dictionary"  => [ "^2\\d\\d", "OK",
                            "^3\\d\\d", "Redirect",
@@ -66,7 +66,7 @@ describe LogStash::Filters::Translate do
     context "when using an inline dictionary" do
       let(:config) do
         {
-          "field"       => "status",
+          "source"      => "status",
           "target"      => "translation",
           "dictionary"  => [ "200", "OK",
                              "300", "Redirect",
@@ -90,7 +90,7 @@ describe LogStash::Filters::Translate do
       let(:dictionary_path)  { TranslateUtil.build_fixture_path("regex_union_dict.csv") }
       let(:config) do
         {
-          "field"       => "status",
+          "source"      => "status",
           "target"      => "translation",
           "dictionary_path" => dictionary_path,
           "refresh_interval" => 0,
@@ -113,7 +113,7 @@ describe LogStash::Filters::Translate do
     context "when using an inline dictionary" do
       let(:config) do
         {
-          "field"       => "status",
+          "source"      => "status",
           "target"      => "translation",
           "dictionary"  => [ "^2[0-9][0-9]$", "OK",
                              "^3[0-9][0-9]$", "Redirect",
@@ -137,7 +137,7 @@ describe LogStash::Filters::Translate do
       let(:dictionary_path)  { TranslateUtil.build_fixture_path("regex_dict.csv") }
       let(:config) do
         {
-          "field"       => "status",
+          "source"      => "status",
           "target"      => "translation",
           "dictionary_path" => dictionary_path,
           "refresh_interval" => 0,
@@ -165,7 +165,7 @@ describe LogStash::Filters::Translate do
       context "static configuration" do
         let(:config) do
           {
-              "field"    => "status",
+              "source"   => "status",
               "target"   => "translation",
               "fallback" => "no match"
           }
@@ -183,7 +183,7 @@ describe LogStash::Filters::Translate do
       context "allow sprintf" do
         let(:config) do
           {
-              "field"    => "status",
+              "source"   => "status",
               "target"   => "translation",
               "fallback" => "%{missing_translation}"
           }
@@ -207,7 +207,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-        "field"       => "status",
+        "source"      => "status",
         "target"      => "translation",
         "dictionary_path"  => dictionary_path,
         "refresh_interval" => -1,
@@ -289,7 +289,7 @@ describe LogStash::Filters::Translate do
     let(:config) do
       {
         "iterate_on"       => "foo",
-        "field"            => iterate_on_field,
+        "source"           => iterate_on_field,
         "target"           => "baz",
         "fallback"         => "nooo",
         "dictionary_path"  => dictionary_path,
@@ -372,7 +372,7 @@ describe LogStash::Filters::Translate do
     let(:dictionary_path)  { TranslateUtil.build_fixture_path("dict.yml") }
     let(:config) do
       {
-        "field"            => "random field",
+        "source"           => "random field",
         "dictionary"       => { "a" => "b" },
         "dictionary_path"  => dictionary_path,
       }
@@ -386,7 +386,7 @@ describe LogStash::Filters::Translate do
   context "invalid target+dictionary configuration" do
     let(:config) do
       {
-          "field"       => "message",
+          "source"      => "message",
           "target"      => 'foo',
           "destination" => 'bar',
       }
@@ -397,17 +397,52 @@ describe LogStash::Filters::Translate do
     end
   end
 
-  context "destination set in ECS mode" do
+  context "destination in ECS mode" do
     let(:config) do
       {
-          "field"       => "message",
-          "destination" => 'bar',
-          "ecs_compatibility" => 'v1'
+          "source" => "message", "destination" => 'bar', "ecs_compatibility" => 'v1'
       }
     end
 
     it "no longer supports the 'destination' field" do
       expect { subject.register }.to raise_error(LogStash::ConfigurationError, /remove .*?destination => /)
+    end
+  end
+
+  context "field option in ECS mode" do
+    let(:config) do
+      {
+          "field" => "message", "target" => 'bar', "ecs_compatibility" => 'v1'
+      }
+    end
+
+    it "no longer supports the 'field' option" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError, /remove .*?field => /)
+    end
+  end
+
+  context "field option in legacy mode" do
+    let(:config) do
+      {
+          "field" => "message", "target" => 'bar', "ecs_compatibility" => 'disabled'
+      }
+    end
+
+    it "still works" do
+      subject.register # does not raise
+      expect( subject.source ).to eql 'message'
+    end
+  end
+
+  context "source option" do
+    let(:config) do
+      {
+          "target" => 'bar'
+      }
+    end
+
+    it "is required to be set" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError, /provide .*?source => /)
     end
   end
 
@@ -418,7 +453,7 @@ describe LogStash::Filters::Translate do
     let(:refresh_behaviour) { "merge" }
     let(:config) do
       {
-        "field" => "status",
+        "source" => "status",
         "target" => "translation",
         "dictionary_path" => dictionary_path,
         "refresh_interval" => -1, # we're controlling this manually
@@ -485,7 +520,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-        "field"       => "status",
+        "source"      => "status",
         "target"      => "translation",
         "dictionary_path"  => dictionary_path.to_path,
         "refresh_interval" => -1,
@@ -540,7 +575,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-          "field" => "message",
+          "source" => "message",
           "dictionary" => { "foo" => "bar" }
       }
     end
@@ -580,7 +615,7 @@ describe LogStash::Filters::Translate do
 
     let(:config) do
       {
-          "field" => "message",
+          "source" => "message",
           "dictionary" => { "foo" => "bar" }
       }
     end

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -354,7 +354,8 @@ describe LogStash::Filters::Translate do
         "destination"      => "foo",
         "dictionary_path"  => dictionary_path,
         "override"         => true,
-        "refresh_interval" => -1
+        "refresh_interval" => -1,
+        "ecs_compatibility" => 'disabled'
       }
     end
 

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -513,4 +513,32 @@ describe LogStash::Filters::Translate do
       end
     end
   end
+
+  describe "error handling" do
+
+    let(:config) do
+      {
+          "field" => "message",
+          "dictionary" => { "foo" => "bar" }
+      }
+    end
+
+    let(:event) { LogStash::Event.new("message" => "foo") }
+
+    before { subject.register }
+
+    it "handles unexpected error within filter" do
+      expect(subject.updater).to receive(:update).and_raise RuntimeError.new('TEST')
+
+      expect { subject.filter(event) }.to_not raise_error
+    end
+
+    it "propagates Java errors" do
+      expect(subject.updater).to receive(:update).and_raise java.lang.OutOfMemoryError.new('FAKE-OUT!')
+
+      expect { subject.filter(event) }.to raise_error(java.lang.OutOfMemoryError)
+    end
+
+  end
+
 end


### PR DESCRIPTION
**This PR makes the plugin compliant with ECS**
by simply using a `target => ` default which makes the plugin act as an in place translator (source = target field).

Some minor tweaks along the way:
- `target` is replacing `destination` to align with plugin convention
- in case of `@field == @target` (ECS default) we no longer require to configure `overwrite => true`
- CI :green_circle: 
- review error handling

closing https://github.com/logstash-plugins/logstash-filter-translate/issues/86