### PR TITLE
Refactor: reading .csv for JRuby 9.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.3.1
+  - Refactor: reading .csv for JRuby 9.3 compatibility [#94](https://github.com/logstash-plugins/logstash-filter-translate/pull/94)
+
+    NOTE: these changes are essential for the plugin to work properly under Logstash 8.3 and later.
+
 ## 3.3.0
   - Feat: added ECS compatibility mode [#89](https://github.com/logstash-plugins/logstash-filter-translate/pull/89)
     - deprecated `destination` option in favor of `target` to better align with other plugins

--- a/lib/logstash/filters/dictionary/csv_file.rb
+++ b/lib/logstash/filters/dictionary/csv_file.rb
@@ -8,7 +8,7 @@ module LogStash module Filters module Dictionary
 
     def read_file_into_dictionary
       ::CSV.open(@dictionary_path, 'r:bom|utf-8') do |csv|
-        csv.each { |row| k,v = row; @dictionary[k] = v }
+        csv.each { |k,v| @dictionary[k] = v }
       end
     end
   end

--- a/lib/logstash/filters/dictionary/csv_file.rb
+++ b/lib/logstash/filters/dictionary/csv_file.rb
@@ -6,19 +6,9 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type
-      @io = StringIO.new("")
-      @csv = ::CSV.new(@io)
-    end
-
     def read_file_into_dictionary
-      # low level CSV read that tries to create as
-      # few intermediate objects as possible
-      # this overwrites the value at key
-      IO.foreach(@dictionary_path, :mode => 'r:bom|utf-8') do |line|
-        @io.string = line
-        k,v = @csv.shift
-        @dictionary[k] = v
+      ::CSV.open(@dictionary_path, 'r:bom|utf-8') do |csv|
+        csv.each { |row| k,v = row; @dictionary[k] = v }
       end
     end
   end

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field contents based on a hash or YAML file"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/scheduling_spec.rb
+++ b/spec/filters/scheduling_spec.rb
@@ -58,7 +58,9 @@ describe LogStash::Filters::Translate do
           end
           .then_after(1.2, "wait then translate again") do
             subject.filter(event)
-            wait(0.1).for{event.get("[translation]")}.to eq("12"), "field [translation] did not eq '12'"
+            try(5) do
+              wait(0.1).for{event.get("[translation]")}.to eq("12"), "field [translation] did not eq '12'"
+            end
           end
           .then("stop") do
             subject.close
@@ -87,7 +89,9 @@ describe LogStash::Filters::Translate do
           end
           .then_after(1.2, "wait then translate again") do
             subject.filter(event)
-            wait(0.1).for{event.get("[translation]")}.to eq("22"), "field [translation] did not eq '22'"
+            try(5) do
+              wait(0.1).for{event.get("[translation]")}.to eq("22"), "field [translation] did not eq '22'"
+            end
           end
           .then("stop") do
             subject.close


### PR DESCRIPTION
**NOTE**: these changes are essential for the plugin to work properly under Logstash 8.3 and later.
:red_circle: CI prior to this PR: https://app.travis-ci.com/github/logstash-plugins/logstash-filter-translate/builds/251684358

---
the code we had seem to have relied on internals - with changing the io object underneath the `CSV`: 
```ruby
      @csv = ::CSV.new(@io = StringIO.new)

      IO.foreach(@dictionary_path, :mode => 'r:bom|utf-8') do |line|
        @io.string = line
        k,v = @csv.readline # working in 9.2, in 9.3 only the first line is read
        @dictionary[k] = v
```
in JRuby 9.3 (which updated CSV library to 3.1.2) a state is kept and the `@io` is not read since start. 

we could have done a `rewind` but this code seemed fragile and the `csv.rewind` resets a lot of it's state, thus refactored to an API usage that is more in-line with how the library is meant to be used.

---

```
      # low level CSV read that tries to create as
      # few intermediate objects as possible
      # this overwrites the value at key
```
following up on the updated CSV code I do not see how it would generate more objects, as far as checked.