### PR TITLE
Fix the limitation of the size of yaml file that exceeds 3MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+  - Fix the limitation of the size of yaml file that exceeds 3MB
+
 ## 3.4.0
  - Refactor: leverage scheduler mixin [#93](https://github.com/logstash-plugins/logstash-filter-translate/pull/93)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.1
-  - Fix the limitation of the size of yaml file that exceeds 3MB
+  - Fix the limitation of the size of yaml file that exceeds 3MB [#97](https://github.com/logstash-plugins/logstash-filter-translate/pull/97)
 
 ## 3.4.0
  - Refactor: leverage scheduler mixin [#93](https://github.com/logstash-plugins/logstash-filter-translate/pull/93)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -154,7 +154,7 @@ NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
 ===== `dictionary_file_max_bytes`
 
   * Value type is <<number,number>>
-  * Default value is 3145728 (3MB)
+  * Default value is 134217728 (128MB)
 
 The maximum size of the file in `dictionary_path`. This setting is effective for YAML file only.
 YAML over the limit throws exception. JSON and CSV currently do not have such restriction.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -96,6 +96,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-destination>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-dictionary>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-dictionary_file_max_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-dictionary_path>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exact>> |<<boolean,boolean>>|No
@@ -148,6 +149,15 @@ Example:
 ----
 
 NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
+
+[id="plugins-{type}s-{plugin}-dictionary_file_max_bytes"]
+===== `dictionary_file_max_bytes`
+
+  * Value type is <<number,number>>
+  * Default value is 3145728 (3MB)
+
+The maximum size of the file in `dictionary_path`. This setting is effective for YAML file only.
+YAML over the limit throws exception. JSON and CSV currently do not have such restriction.
 
 [id="plugins-{type}s-{plugin}-dictionary_path"]
 ===== `dictionary_path`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -427,7 +427,7 @@ the filter will succeed. This will clobber the old value of the source field!
 ===== `yaml_dictionary_code_point_limit`
 
 * Value type is <<number,number>>
-* Default value is 134217728 (128MB)
+* Default value is 134217728 (128MB for 1 byte code points)
 
 The max amount of code points in the YAML file in `dictionary_path`. Please be aware that byte limit depends on the encoding.
 This setting is effective for YAML file only. YAML over the limit throws exception.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -96,7 +96,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-destination>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-dictionary>> |<<hash,hash>>|No
-| <<plugins-{type}s-{plugin}-dictionary_file_max_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-dictionary_path>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-exact>> |<<boolean,boolean>>|No
@@ -109,6 +108,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-source>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-refresh_behaviour>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-yaml_dictionary_code_point_limit>> |<<number,number>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -149,15 +149,6 @@ Example:
 ----
 
 NOTE: It is an error to specify both `dictionary` and `dictionary_path`.
-
-[id="plugins-{type}s-{plugin}-dictionary_file_max_bytes"]
-===== `dictionary_file_max_bytes`
-
-  * Value type is <<number,number>>
-  * Default value is 134217728 (128MB)
-
-The maximum size of the file in `dictionary_path`. This setting is effective for YAML file only.
-YAML over the limit throws exception. JSON and CSV currently do not have such restriction.
 
 [id="plugins-{type}s-{plugin}-dictionary_path"]
 ===== `dictionary_path`
@@ -430,6 +421,16 @@ If this field is an array, only the first value will be used.
 The target field you wish to populate with the translated code.
 If you set this value to the same value as `source` field, the plugin does a substitution, and
 the filter will succeed. This will clobber the old value of the source field!
+
+
+[id="plugins-{type}s-{plugin}-yaml_dictionary_code_point_limit"]
+===== `yaml_dictionary_code_point_limit`
+
+* Value type is <<number,number>>
+* Default value is 134217728 (128MB)
+
+The max amount of code points in the YAML file in `dictionary_path`. Please be aware that byte limit depends on the encoding.
+This setting is effective for YAML file only. YAML over the limit throws exception.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -68,7 +68,7 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type(file_max_bytes)
+    def initialize_for_file_type(yaml_code_point_limit)
       # sub class specific initializer
     end
 

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -39,7 +39,7 @@ module LogStash module Filters module Dictionary
       @write_lock = rw_lock.writeLock
       @dictionary = Hash.new
       @update_method = method(:merge_dictionary)
-      initialize_for_file_type(file_max_bytes)
+      initialize_for_file_type(yaml_code_point_limit)
       args = [@dictionary, rw_lock]
       klass = case
               when exact && regex then FetchStrategy::File::ExactRegex

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -55,7 +55,7 @@ module LogStash module Filters module Dictionary
         @dictionary_mtime = ::File.mtime(@dictionary_path).to_f
         @update_method.call
       rescue Errno::ENOENT
-        @logger.warn("dictionary file read failure, continuing with old dictionary", :path => @dictionary_path)
+        logger.warn("dictionary file read failure, continuing with old dictionary", :path => @dictionary_path)
       rescue => e
         loading_exception(e, raise_exception)
       end
@@ -120,7 +120,7 @@ module LogStash module Filters module Dictionary
         dfe.set_backtrace(e.backtrace)
         raise dfe
       else
-        @logger.warn("#{msg}, continuing with old dictionary", :dictionary_path => @dictionary_path)
+        logger.warn("#{msg}, continuing with old dictionary", :dictionary_path => @dictionary_path)
       end
     end
   end

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -31,7 +31,7 @@ module LogStash module Filters module Dictionary
 
     attr_reader :dictionary, :fetch_strategy
 
-    def initialize(path, refresh_interval, exact, regex, file_max_bytes = nil)
+    def initialize(path, refresh_interval, exact, regex, yaml_code_point_limit = nil)
       @dictionary_path = path
       @refresh_interval = refresh_interval
       @short_refresh = @refresh_interval <= 300

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -31,7 +31,7 @@ module LogStash module Filters module Dictionary
 
     attr_reader :dictionary, :fetch_strategy
 
-    def initialize(path, refresh_interval, exact, regex, yaml_code_point_limit = nil)
+    def initialize(path, refresh_interval, exact, regex, **file_type_args)
       @dictionary_path = path
       @refresh_interval = refresh_interval
       @short_refresh = @refresh_interval <= 300

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -39,7 +39,7 @@ module LogStash module Filters module Dictionary
       @write_lock = rw_lock.writeLock
       @dictionary = Hash.new
       @update_method = method(:merge_dictionary)
-      initialize_for_file_type(yaml_code_point_limit)
+      initialize_for_file_type(yaml_code_point_limit: file_type_args[:yaml_code_point_limit])
       args = [@dictionary, rw_lock]
       klass = case
               when exact && regex then FetchStrategy::File::ExactRegex

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -9,9 +9,9 @@ module LogStash module Filters module Dictionary
 
     include LogStash::Util::Loggable
 
-    def self.create(path, refresh_interval, refresh_behaviour, exact, regex, yaml_code_point_limit)
+    def self.create(path, refresh_interval, refresh_behaviour, exact, regex, **file_type_args)
       if /\.y[a]?ml$/.match(path)
-        instance = YamlFile.new(path, refresh_interval, exact, regex, yaml_code_point_limit)
+        instance = YamlFile.new(path, refresh_interval, exact, regex, file_type_args)
       elsif path.end_with?(".json")
         instance = JsonFile.new(path, refresh_interval, exact, regex)
       elsif path.end_with?(".csv")
@@ -39,7 +39,7 @@ module LogStash module Filters module Dictionary
       @write_lock = rw_lock.writeLock
       @dictionary = Hash.new
       @update_method = method(:merge_dictionary)
-      initialize_for_file_type(yaml_code_point_limit: file_type_args[:yaml_code_point_limit])
+      initialize_for_file_type(file_type_args)
       args = [@dictionary, rw_lock]
       klass = case
               when exact && regex then FetchStrategy::File::ExactRegex

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -68,7 +68,7 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type(yaml_code_point_limit)
+    def initialize_for_file_type(**file_type_args)
       # sub class specific initializer
     end
 

--- a/lib/logstash/filters/dictionary/file.rb
+++ b/lib/logstash/filters/dictionary/file.rb
@@ -9,9 +9,9 @@ module LogStash module Filters module Dictionary
 
     include LogStash::Util::Loggable
 
-    def self.create(path, refresh_interval, refresh_behaviour, exact, regex, params)
+    def self.create(path, refresh_interval, refresh_behaviour, exact, regex, yaml_code_point_limit)
       if /\.y[a]?ml$/.match(path)
-        instance = YamlFile.new(path, refresh_interval, exact, regex, params["dictionary_file_max_bytes"])
+        instance = YamlFile.new(path, refresh_interval, exact, regex, yaml_code_point_limit)
       elsif path.end_with?(".json")
         instance = JsonFile.new(path, refresh_interval, exact, regex)
       elsif path.end_with?(".csv")

--- a/lib/logstash/filters/dictionary/json_file.rb
+++ b/lib/logstash/filters/dictionary/json_file.rb
@@ -6,9 +6,6 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type
-    end
-
     def read_file_into_dictionary
       content = IO.read(@dictionary_path, :mode => 'r:bom|utf-8')
       @dictionary.update(LogStash::Json.load(content)) unless content.nil? || content.empty?

--- a/lib/logstash/filters/dictionary/yaml_file.rb
+++ b/lib/logstash/filters/dictionary/yaml_file.rb
@@ -7,11 +7,11 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type(file_max_bytes)
+    def initialize_for_file_type(yaml_code_point_limit)
       @visitor = YamlVisitor.create
 
       @parser = Psych::Parser.new(Psych::TreeBuilder.new)
-      @parser.code_point_limit = file_max_bytes
+      @parser.code_point_limit = yaml_code_point_limit
     end
 
     def read_file_into_dictionary

--- a/lib/logstash/filters/dictionary/yaml_file.rb
+++ b/lib/logstash/filters/dictionary/yaml_file.rb
@@ -7,18 +7,20 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type
+    def initialize_for_file_type(file_max_bytes)
       @visitor = YamlVisitor.create
+
+      @parser = Psych::Parser.new(Psych::TreeBuilder.new)
+      @parser.code_point_limit = file_max_bytes
     end
 
     def read_file_into_dictionary
       # low level YAML read that tries to create as
       # few intermediate objects as possible
       # this overwrites the value at key
-      @visitor.accept_with_dictionary(
-        @dictionary, Psych.parse_stream(
-          IO.read(@dictionary_path, :mode => 'r:bom|utf-8')
-      ))
+      yaml_string = IO.read(@dictionary_path, :mode => 'r:bom|utf-8')
+      @parser.parse(yaml_string, @dictionary_path)
+      @visitor.accept_with_dictionary(@dictionary, @parser.handler.root)
     end
   end
 end end end

--- a/lib/logstash/filters/dictionary/yaml_file.rb
+++ b/lib/logstash/filters/dictionary/yaml_file.rb
@@ -7,11 +7,11 @@ module LogStash module Filters module Dictionary
 
     protected
 
-    def initialize_for_file_type(yaml_code_point_limit)
+    def initialize_for_file_type(**file_type_args)
       @visitor = YamlVisitor.create
 
       @parser = Psych::Parser.new(Psych::TreeBuilder.new)
-      @parser.code_point_limit = yaml_code_point_limit
+      @parser.code_point_limit = file_type_args[:yaml_code_point_limit]
     end
 
     def read_file_into_dictionary

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -105,7 +105,8 @@ class Translate < LogStash::Filters::Base
   # Setting the maximum bytes size of the file in `dictionary_path`. This setting is effective for YAML file only.
   # Snakeyaml 1.33 has a default limit 3MB. YAML file over the limit throws exception. JSON and CSV currently do not have such limit.
   # The limit could be too small in some use cases. Setting a bigger number in `dictionary_file_max_bytes` to relax the restriction.
-  config :dictionary_file_max_bytes, :validate => :number, :default => 3_145_728
+  # The default value is 128MB
+  config :dictionary_file_max_bytes, :validate => :number, :default => 134_217_728
 
   # When using a dictionary file, this setting will indicate how frequently
   # (in seconds) logstash will check the dictionary file for updates.

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -187,6 +187,7 @@ class Translate < LogStash::Filters::Base
     end
 
     # check and set yaml code point limit
+    # set lookup dictionary
     if @dictionary_path
       if yaml_file?(@dictionary_path)
         @yaml_dictionary_code_point_limit ||= 134_217_728

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -193,14 +193,14 @@ class Translate < LogStash::Filters::Base
 
         if @yaml_dictionary_code_point_limit <= 0
           raise LogStash::ConfigurationError, "Please set a positive number in `yaml_dictionary_code_point_limit => #{@yaml_dictionary_code_point_limit}`."
+        else
+          @lookup = Dictionary::File.create(@dictionary_path, @refresh_interval, @refresh_behaviour, @exact, @regex, yaml_code_point_limit: @yaml_dictionary_code_point_limit)
         end
       elsif @yaml_dictionary_code_point_limit != nil
         raise LogStash::ConfigurationError, "Please remove `yaml_dictionary_code_point_limit` for dictionary file in JSON or CSV format"
+      else
+        @lookup = Dictionary::File.create(@dictionary_path, @refresh_interval, @refresh_behaviour, @exact, @regex)
       end
-    end
-
-    if @dictionary_path
-      @lookup = Dictionary::File.create(@dictionary_path, @refresh_interval, @refresh_behaviour, @exact, @regex, @yaml_dictionary_code_point_limit)
     else
       @lookup = Dictionary::Memory.new(@dictionary, @exact, @regex)
     end

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -105,7 +105,7 @@ class Translate < LogStash::Filters::Base
   # The max amount of code points in the YAML file in `dictionary_path`. Please be aware that byte limit depends on the encoding.
   # Snakeyaml 1.33 has a default limit 3MB. YAML file over the limit throws exception. JSON and CSV currently do not have such limit.
   # The limit could be too small in some use cases. Setting a bigger number in `yaml_dictionary_code_point_limit` to relax the restriction.
-  # The default value is 128MB
+  # The default value is 128MB for code points of size 1 byte
   config :yaml_dictionary_code_point_limit, :validate => :number
 
   # When using a dictionary file, this setting will indicate how frequently

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field contents based on a hash or YAML file"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-deprecation_logger_support', '~> 1.0'
   s.add_runtime_dependency "logstash-mixin-scheduler", '~> 1.0'
+  s.add_runtime_dependency "psych", ">= 5.1.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec-sequencing'

--- a/spec/filters/scheduling_spec.rb
+++ b/spec/filters/scheduling_spec.rb
@@ -56,9 +56,9 @@ describe LogStash::Filters::Translate do
               file.puts("a,11\nb,12\nc,13\n")
             end
           end
-          .then_after(2, "wait then translate again") do
-            subject.filter(event)
+          .then_after(1.2, "wait then translate again") do
             try(5) do
+              subject.filter(event)
               wait(0.5).for{event.get("[translation]")}.to eq("12"), "field [translation] did not eq '12'"
             end
           end
@@ -87,9 +87,9 @@ describe LogStash::Filters::Translate do
               file.puts("a,21\nb,22\nc,23\n")
             end
           end
-          .then_after(2, "wait then translate again") do
-            subject.filter(event)
+          .then_after(1.2, "wait then translate again") do
             try(5) do
+              subject.filter(event)
               wait(0.5).for{event.get("[translation]")}.to eq("22"), "field [translation] did not eq '22'"
             end
           end

--- a/spec/filters/scheduling_spec.rb
+++ b/spec/filters/scheduling_spec.rb
@@ -56,10 +56,10 @@ describe LogStash::Filters::Translate do
               file.puts("a,11\nb,12\nc,13\n")
             end
           end
-          .then_after(1.2, "wait then translate again") do
+          .then_after(2, "wait then translate again") do
             subject.filter(event)
             try(5) do
-              wait(0.1).for{event.get("[translation]")}.to eq("12"), "field [translation] did not eq '12'"
+              wait(0.5).for{event.get("[translation]")}.to eq("12"), "field [translation] did not eq '12'"
             end
           end
           .then("stop") do
@@ -87,10 +87,10 @@ describe LogStash::Filters::Translate do
               file.puts("a,21\nb,22\nc,23\n")
             end
           end
-          .then_after(1.2, "wait then translate again") do
+          .then_after(2, "wait then translate again") do
             subject.filter(event)
             try(5) do
-              wait(0.1).for{event.get("[translation]")}.to eq("22"), "field [translation] did not eq '22'"
+              wait(0.5).for{event.get("[translation]")}.to eq("22"), "field [translation] did not eq '22'"
             end
           end
           .then("stop") do


### PR DESCRIPTION
Fixed: #96

added setting `yaml_dictionary_code_point_limit` to config the maximum code point limit of the yaml file in `dictionary_path` to overcome the 3MB size limit from SnakeYaml 1.33. This setting is only effective for yaml.  Yaml file over the size limit throws an exception. JSON and CSV currently do not have such restriction. The default value of `yaml_dictionary_code_point_limit` is 128MB.

## How to test

- checkout the branch
- build the gem 
  - bundle install
  - gem build logstash-filter-translate.gemspec
- install the gem in Logstash
  - bin/logstash-plugin install --local ~/path/to/your/gem/logstash-filter-translate-3.4.1.gem
- download a 4MB yaml from [here](https://raw.githubusercontent.com/kaisecheng/fixture/main/yml/big_yaml_4mb.yml)
- run the following config
```
input {
  file {
    path => "/path/to/yaml/big_yaml_4mb.yml"
    start_position => "beginning"
  }
}
filter {
  dissect {
    mapping => {
      "message" => "%{key}: %{val}"
    }
  }
  translate {
    source => "key"
    target => "translated"
    fallback => "UNKNOWN"
    dictionary_path => "/path/to/yaml/big_yaml_4mb.yml"
    yaml_dictionary_code_point_limit => 5000000
  }
}
output {
    stdout { codec => dots }
}
```
- Logstash should start without error