### PR TITLE
implementation of streaming yaml parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+  - Introduce opt-in "yaml_load_strategy => streaming" to stream parse YAML dictionaries [#106](https://github.com/logstash-plugins/logstash-filter-translate/pull/106)
+
 ## 3.4.3
   - Allow YamlFile's Psych::Parser and Visitor instances to be garbage collected [#104](https://github.com/logstash-plugins/logstash-filter-translate/pull/104)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -109,6 +109,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-refresh_behaviour>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-yaml_dictionary_code_point_limit>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-yaml_load_strategy>> |<<string,string>>, one of `["one_shot", "streaming"]`|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -431,6 +432,22 @@ the filter will succeed. This will clobber the old value of the source field!
 
 The max amount of code points in the YAML file in `dictionary_path`. Please be aware that byte limit depends on the encoding.
 This setting is effective for YAML file only. YAML over the limit throws exception.
+
+[id="plugins-{type}s-{plugin}-yaml_load_strategy"]
+===== `yaml_load_strategy`
+
+* Value can be any of: `one_shot`, `streaming`
+* Default value is `one_shot`
+
+How to load and parse the YAML file. This setting defaults to `one_shot`, which loads the entire
+YAML file into the parser in one go, emitting the final dictionary from the fully parsed YAML document.
+
+Setting to `streaming` will instead instruct the parser to emit one "YAML element" at a time, constructing the dictionary
+during parsing. This mode drastically reduces the amount of memory required to load or refresh the dictionary and it is also faster.
+
+Due to underlying implementation differences this mode only supports basic types such as Arrays, Objects, Strings, numbers and booleans, and does not support tags.
+
+If you have a lot of translate filters with large YAML documents consider changing this setting to `streaming` instead.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
+++ b/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
@@ -1,0 +1,107 @@
+java_import 'org.snakeyaml.engine.v2.api.LoadSettings'
+java_import 'org.snakeyaml.engine.v2.parser.ParserImpl'
+java_import 'org.snakeyaml.engine.v2.scanner.StreamReader'
+java_import 'java.io.FileInputStream'
+java_import 'java.io.InputStreamReader'
+java_import 'java.nio.charset.StandardCharsets'
+java_import 'org.snakeyaml.engine.v2.events.MappingStartEvent'
+java_import 'org.snakeyaml.engine.v2.events.MappingEndEvent'
+java_import 'org.snakeyaml.engine.v2.events.SequenceStartEvent'
+java_import 'org.snakeyaml.engine.v2.events.SequenceEndEvent'
+java_import 'org.snakeyaml.engine.v2.events.ScalarEvent'
+
+module LogStash module Filters module Dictionary
+  class StreamingYamlDictParser
+    def initialize(filename)
+      settings = LoadSettings.builder.build
+
+      stream = FileInputStream.new(filename)
+      reader = InputStreamReader.new(stream, StandardCharsets::UTF_8)
+      stream_reader = StreamReader.new(reader, settings)
+
+      @parser = ParserImpl.new(stream_reader, settings)
+      @next_event = nil
+
+      skip_until(MappingStartEvent)
+    end
+
+
+    def each_pair
+      while peek_event && !peek_event.is_a?(MappingEndEvent)
+        key = parse_node
+        value = parse_node
+        yield(key, value)
+      end
+    end
+
+    private
+
+    def next_event
+      @next_event || @parser.next
+    ensure
+      @next_event = nil
+    end
+
+    def peek_event
+      @next_event ||= @parser.next
+    end
+
+    def skip_until(event_class)
+      while @parser.has_next
+        evt = @parser.next
+        return if event_class === evt
+      end
+    end
+
+    def parse_node
+      event = next_event
+
+      case event
+      when ScalarEvent
+        parse_scalar(event.value)
+      when MappingStartEvent
+        parse_mapping
+      when SequenceStartEvent
+        parse_sequence
+      else
+        raise "Unexpected event: #{event.class}"
+      end
+    end
+
+    def parse_mapping
+      hash = {}
+      while peek_event && !peek_event.is_a?(MappingEndEvent)
+        key = parse_node
+        value = parse_node
+        hash[key] = value
+      end
+      next_event # consume MappingEndEvent
+      hash
+    end
+
+    def parse_sequence
+      array = []
+      while peek_event && !peek_event.is_a?(SequenceEndEvent)
+        array << parse_node
+      end
+      next_event # consume SequenceEndEvent
+      array
+    end
+    def parse_scalar(value)
+      case value
+      when 'null', '', '~' then nil
+      when 'true' then true
+      when 'false' then false
+      else
+        # Try to convert to integer or float
+        if value.match?(/\A-?\d+\z/)
+          value.to_i
+        elsif value.match?(/\A-?\d+\.\d+\z/)
+          value.to_f
+        else
+          value  # keep as string
+        end
+      end
+    end
+  end
+end end end

--- a/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
+++ b/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
@@ -59,7 +59,7 @@ module LogStash module Filters module Dictionary
 
       case event
       when ScalarEvent
-        parse_scalar(event.value)
+        parse_scalar(event)
       when MappingStartEvent
         parse_mapping
       when SequenceStartEvent
@@ -88,7 +88,13 @@ module LogStash module Filters module Dictionary
       next_event
       array
     end
-    def parse_scalar(value)
+    def parse_scalar(scalar)
+      value = scalar.value
+      # return quoted scalars as they are
+      # e.g. don't convert "true" to true
+      return value unless scalar.is_plain
+
+      # otherwise let's do some checking and conversions
       case value
       when 'null', '', '~' then nil
       when 'true' then true

--- a/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
+++ b/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
@@ -5,7 +5,7 @@ module LogStash module Filters module Dictionary
     end
 
     def snakeYamlEngineV2Events
-      Java::org.snakeyaml.engine.v2.events
+      snakeYamlEngineV2.events
     end
 
     def initialize(filename, yaml_code_point_limit)

--- a/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
+++ b/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
@@ -84,6 +84,7 @@ module LogStash module Filters module Dictionary
       next_event
       array
     end
+    
     def parse_scalar(scalar)
       value = scalar.value
       # return quoted scalars as they are

--- a/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
+++ b/lib/logstash/filters/dictionary/streaming_yaml_parser.rb
@@ -1,34 +1,30 @@
-java_import 'org.snakeyaml.engine.v2.api.LoadSettings'
-java_import 'org.snakeyaml.engine.v2.parser.ParserImpl'
-java_import 'org.snakeyaml.engine.v2.scanner.StreamReader'
-java_import 'java.io.FileInputStream'
-java_import 'java.io.InputStreamReader'
-java_import 'java.nio.charset.StandardCharsets'
-java_import 'org.snakeyaml.engine.v2.events.MappingStartEvent'
-java_import 'org.snakeyaml.engine.v2.events.MappingEndEvent'
-java_import 'org.snakeyaml.engine.v2.events.SequenceStartEvent'
-java_import 'org.snakeyaml.engine.v2.events.SequenceEndEvent'
-java_import 'org.snakeyaml.engine.v2.events.ScalarEvent'
-
 module LogStash module Filters module Dictionary
   class StreamingYamlDictParser
+    def snakeYamlEngineV2
+      Java::org.snakeyaml.engine.v2
+    end
+
+    def snakeYamlEngineV2Events
+      Java::org.snakeyaml.engine.v2.events
+    end
+
     def initialize(filename, yaml_code_point_limit)
-      settings = LoadSettings.builder
+      settings = snakeYamlEngineV2.api.LoadSettings.builder
         .set_code_point_limit(yaml_code_point_limit)
         .build
 
-      stream = FileInputStream.new(filename)
-      reader = InputStreamReader.new(stream, StandardCharsets::UTF_8)
-      stream_reader = StreamReader.new(reader, settings)
+      stream = Java::java.io.FileInputStream.new(filename)
+      reader = Java::java.io.InputStreamReader.new(stream, Java::java.nio.charset.StandardCharsets::UTF_8)
+      stream_reader = snakeYamlEngineV2.scanner.StreamReader.new(reader, settings)
 
-      @parser = ParserImpl.new(stream_reader, settings)
+      @parser = snakeYamlEngineV2.parser.ParserImpl.new(stream_reader, settings)
 
-      skip_until(MappingStartEvent)
+      skip_until(snakeYamlEngineV2Events.MappingStartEvent)
     end
 
 
     def each_pair
-      while peek_event && !peek_event.is_a?(MappingEndEvent)
+      while peek_event && !peek_event.is_a?(snakeYamlEngineV2Events.MappingEndEvent)
         key = parse_node
         value = parse_node
         yield(key, value)
@@ -58,11 +54,11 @@ module LogStash module Filters module Dictionary
       event = next_event
 
       case event
-      when ScalarEvent
+      when snakeYamlEngineV2Events.ScalarEvent
         parse_scalar(event)
-      when MappingStartEvent
+      when snakeYamlEngineV2Events.MappingStartEvent
         parse_mapping
-      when SequenceStartEvent
+      when snakeYamlEngineV2Events.SequenceStartEvent
         parse_sequence
       else
         raise "Unexpected event: #{event.class}"
@@ -71,7 +67,7 @@ module LogStash module Filters module Dictionary
 
     def parse_mapping
       hash = {}
-      while peek_event && !peek_event.is_a?(MappingEndEvent)
+      while peek_event && !peek_event.is_a?(snakeYamlEngineV2Events.MappingEndEvent)
         key = parse_node
         value = parse_node
         hash[key] = value
@@ -82,7 +78,7 @@ module LogStash module Filters module Dictionary
 
     def parse_sequence
       array = []
-      while peek_event && !peek_event.is_a?(SequenceEndEvent)
+      while peek_event && !peek_event.is_a?(snakeYamlEngineV2Events.SequenceEndEvent)
         array << parse_node
       end
       next_event

--- a/lib/logstash/filters/dictionary/yaml_file.rb
+++ b/lib/logstash/filters/dictionary/yaml_file.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require_relative "yaml_visitor"
+require_relative "streaming_yaml_parser"
 
 module LogStash module Filters module Dictionary
   class YamlFile < File
@@ -12,15 +13,25 @@ module LogStash module Filters module Dictionary
     end
 
     def read_file_into_dictionary
-      visitor = YamlVisitor.create
-      parser = Psych::Parser.new(Psych::TreeBuilder.new)
-      parser.code_point_limit = @yaml_code_point_limit
-      # low level YAML read that tries to create as
-      # few intermediate objects as possible
-      # this overwrites the value at key
-      yaml_string = IO.read(@dictionary_path, :mode => 'r:bom|utf-8')
-      parser.parse(yaml_string, @dictionary_path)
-      visitor.accept_with_dictionary(@dictionary, parser.handler.root)
+      if ENV['YAML_PARSER'] == 'psych'
+        visitor = YamlVisitor.create
+        parser = Psych::Parser.new(Psych::TreeBuilder.new)
+        parser.code_point_limit = @yaml_code_point_limit
+        # low level YAML read that tries to create as
+        # few intermediate objects as possible
+        # this overwrites the value at key
+        yaml_string = IO.read(@dictionary_path, :mode => 'r:bom|utf-8')
+        parser.parse(yaml_string, @dictionary_path)
+        visitor.accept_with_dictionary(@dictionary, parser.handler.root)
+        sleep 100
+      else
+        parser = StreamingYamlDictParser.new(@dictionary_path)
+
+        parser.each_pair do |key, value|
+          @dictionary[key] = value
+        end
+        sleep 100
+      end
     end
   end
 end end end

--- a/lib/logstash/filters/translate.rb
+++ b/lib/logstash/filters/translate.rb
@@ -108,6 +108,10 @@ class Translate < LogStash::Filters::Base
   # The default value is 128MB for code points of size 1 byte
   config :yaml_dictionary_code_point_limit, :validate => :number
 
+  # either load the entire yaml into memory before generating the in-memory dictionary
+  # alternatively "streaming" will gradually build the dictionary with little memory overhead
+  config :yaml_load_strategy, :validate => ["streaming", "one_shot"], :default => "one_shot"
+
   # When using a dictionary file, this setting will indicate how frequently
   # (in seconds) logstash will check the dictionary file for updates.
   config :refresh_interval, :validate => :number, :default => 300
@@ -195,7 +199,7 @@ class Translate < LogStash::Filters::Base
         if @yaml_dictionary_code_point_limit <= 0
           raise LogStash::ConfigurationError, "Please set a positive number in `yaml_dictionary_code_point_limit => #{@yaml_dictionary_code_point_limit}`."
         else
-          @lookup = Dictionary::File.create(@dictionary_path, @refresh_interval, @refresh_behaviour, @exact, @regex, yaml_code_point_limit: @yaml_dictionary_code_point_limit)
+          @lookup = Dictionary::File.create(@dictionary_path, @refresh_interval, @refresh_behaviour, @exact, @regex, yaml_code_point_limit: @yaml_dictionary_code_point_limit, yaml_load_strategy: @yaml_load_strategy)
         end
       elsif @yaml_dictionary_code_point_limit != nil
         raise LogStash::ConfigurationError, "Please remove `yaml_dictionary_code_point_limit` for dictionary file in JSON or CSV format"

--- a/logstash-filter-translate.gemspec
+++ b/logstash-filter-translate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-translate'
-  s.version         = '3.4.3'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Replaces field contents based on a hash or YAML file"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/translate_spec.rb
+++ b/spec/filters/translate_spec.rb
@@ -250,8 +250,6 @@ describe LogStash::Filters::Translate do
         let(:one_shot_dictionary) { one_shot_parse_filter.lookup.dictionary }
         let(:streaming_dictionary) { streaming_parse_filter.lookup.dictionary }
         it "produces an equivalent dictionary for both strategies" do
-          puts one_shot_dictionary.inspect
-          puts streaming_dictionary.inspect
           expect(one_shot_dictionary).to eq(streaming_dictionary)
         end
       end

--- a/spec/fixtures/dict.yml
+++ b/spec/fixtures/dict.yml
@@ -1,3 +1,4 @@
 a : 1
 b : 2
 c : 3
+c : { d: [1, "hello", true, "false", "1", "1.1"] }

--- a/spec/fixtures/dict.yml
+++ b/spec/fixtures/dict.yml
@@ -1,4 +1,4 @@
 a : 1
 b : 2
 c : 3
-c : { d: [1, "hello", true, "false", "1", "1.1"] }
+d : { "e": [1, "hello", true, "false", "1", "1.1"] }


### PR DESCRIPTION
Instead of running Psych::Parse which creates the entire Psych-based Tree before emitting the ruby hash dictionary, the plugin should be capable of gradually constructing the final hash dictionary as the parser identifies YAML elements (streaming parsing).

This changeset adds an opt-in streaming parsing for YAML files based on snakeyaml-engine.

The difference in loading a 26MB YAML with 50.000 entries of objects is significant in terms of memory pressure.

With the current psych parser in non streaming mode, memory required to load the YAML + generate the final dictionary is about 1GB:

<img width="662" height="387" alt="Screenshot 2025-07-30 at 11 10 05" src="https://github.com/user-attachments/assets/efbf7ccc-34b1-49b3-9adf-39aaa2fdd6a4" />

With this PR using a streaming snakeyaml-engine parser is about 330MB:

<img width="622" height="350" alt="Screenshot 2025-07-30 at 11 12 20" src="https://github.com/user-attachments/assets/50e4552a-b896-45eb-9ca4-ba1a40905ab9" />

It also reduces loading time from 6 seconds to 2 on my laptop.

fixes #107 